### PR TITLE
fix v-for elements in iteration expect

### DIFF
--- a/src/popup/components/RecordingTab.vue
+++ b/src/popup/components/RecordingTab.vue
@@ -9,7 +9,7 @@
       <div class="events" v-show="isRecording">
         <p class="text-muted text-center" v-show="liveEvents.length === 0">Waiting for events...</p>
         <ul class="event-list">
-          <li v-for="(event, index) in liveEvents" class="event-list-item">
+          <li v-for="(event, index) in liveEvents" :key="index" class="event-list-item">
             <div class="event-label">
               {{index + 1}}.
             </div>


### PR DESCRIPTION
To give Vue a hint so that it can track each node’s identity, and thus reuse and reorder existing elements, you need to provide a unique `key` attribute for each item.