### PR TITLE
Features and Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project is pretty fresh, but does the following already:
 ## Usage
 
 - Click the icon and hit Record.
-- Hit <kbd>enter</kbd> after you finish typing in an `input` element.
+- Hit <kbd>control</kbd> after you finish typing in an `input` element.
 - Click links, inputs and other elements.
 - Wait for full page load on each navigation. The icon will switch from ![](src/images/icon_rec.png) to ![](src/images/icon_wait.png).
 - Click Pause when you want to navigate without recording anything. Hit Resume to continue recording.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project is pretty fresh, but does the following already:
 ## Usage
 
 - Click the icon and hit Record.
-- Hit <kbd>control</kbd> after you finish typing in an `input` element.
+- Hit <kbd>tab</kbd> after you finish typing in an `input` element. The keycode is configurable in the options.
 - Click links, inputs and other elements.
 - Wait for full page load on each navigation. The icon will switch from ![](src/images/icon_rec.png) to ![](src/images/icon_wait.png).
 - Click Pause when you want to navigate without recording anything. Hit Resume to continue recording.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 [![coffee](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/UJGejcNli)
 
 ![](src/images/recorder.png)
-Puppeteer recorder is a Chrome extension that records your browser interactions and generates a 
+Puppeteer recorder is a Chrome extension that records your browser interactions and generates a
 [Puppeteer](https://github.com/GoogleChrome/puppeteer) script. Install it from the [Chrome Webstore](https://chrome.google.com/webstore/detail/puppeteer-recorder/djeegiggegleadkkbgopoonhjimgehda).
 This project is pretty fresh, but does the following already:
 
 - Records clicks and type events.
-- Add waitForNavigation, setViewPort and other useful clauses. 
+- Add waitForNavigation, setViewPort and other useful clauses.
 - Generates a Puppeteer script.
 - Shows which events are being recorded.
 - Copy to clipboard.
@@ -21,14 +21,14 @@ This project is pretty fresh, but does the following already:
 ## Usage
 
 - Click the icon and hit Record.
-- Hit <kbd>tab</kbd> after you finish typing in an `input` element.
+- Hit <kbd>enter</kbd> after you finish typing in an `input` element.
 - Click links, inputs and other elements.
 - Wait for full page load on each navigation. The icon will switch from ![](src/images/icon_rec.png) to ![](src/images/icon_wait.png).
-- Click Pause when you want to navigate without recording anything. Hit Resume to continue recording. 
+- Click Pause when you want to navigate without recording anything. Hit Resume to continue recording.
 ## Background
 
 Writing Puppeteer scripts for scraping, testing and monitoring can be tricky. A recorder / code generator can be helpful,
-even if the code isn't perfect. This project builds on other projects (see [disclaimer](#user-content-credits--disclaimer) 
+even if the code isn't perfect. This project builds on other projects (see [disclaimer](#user-content-credits--disclaimer)
 below) but add extensibility, configurability and a smoother UI.
 
 ## Development
@@ -55,7 +55,7 @@ gren release --override --data-source=milestones --milestone-match="{{tag_name}}
 
 ## Credits & disclaimer
 
-Puppeteer recorder is the spiritual successor & love child of segment.io's 
+Puppeteer recorder is the spiritual successor & love child of segment.io's
 [Daydream](https://github.com/segmentio/daydream) and [ui recorder](https://github.com/yguan/ui-recorder).
 
 ## License

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "npm run unit-test && npm run e2e-test",
     "test-prod": "NODE_ENV=production npm run unit-test && npm run e2e-test",
     "unit-test": "jest __tests__/.*.spec.js --silent",
-    "e2e-test": "jest __e2e-tests__ --runInBand --silent"
+    "e2e-test": "jest __e2e-tests__ --runInBand --silent",
+    "unit-test-update": "jest __tests__/.*.spec.js --updateSnapshot"
   },
   "pre-commit": [
     "test-prod"

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -18,8 +18,13 @@ class RecordingController {
         if (msg.action && msg.action === 'cleanUp') this.cleanUp()
         if (msg.action && msg.action === 'pause') this.pause()
         if (msg.action && msg.action === 'unpause') this.unPause()
+        if (msg.action && msg.action === 'add-wait') this.addWait()
       })
     })
+  }
+
+  addWait(){
+    this.handleMessage({ action: pptrActions.ADD_WAIT });
   }
 
   start () {

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -19,12 +19,17 @@ class RecordingController {
         if (msg.action && msg.action === 'pause') this.pause()
         if (msg.action && msg.action === 'unpause') this.unPause()
         if (msg.action && msg.action === 'add-wait') this.addWait()
+        if (msg.action && msg.action === 'text-click') this.textClick()
       })
     })
   }
 
   addWait(){
     this.handleMessage({ action: pptrActions.ADD_WAIT });
+  }
+
+  textClick(){
+    this.handleMessage({ action: pptrActions.TEXT_CLICK });
   }
 
   start () {

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -106,6 +106,7 @@ class RecordingController {
   recordCurrentUrl (href) {
     console.debug('recording goto* for:', href)
     this.handleMessage({ selector: undefined, value: undefined, action: pptrActions.GOTO, href })
+    this.handleMessage({ action: pptrActions.SET_LOCAL_STORAGE })
   }
 
   recordCurrentViewportSize (value) {
@@ -118,7 +119,6 @@ class RecordingController {
 
   handleMessage (msg, sender) {
     if (msg.control) return this.handleControlMessage(msg, sender)
-
     // to account for clicks etc. we need to record the frameId and url to later target the frame in playback
     msg.frameId = sender ? sender.frameId : null
     msg.frameUrl = sender ? sender.url : null

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -18,14 +18,19 @@ class RecordingController {
         if (msg.action && msg.action === 'cleanUp') this.cleanUp()
         if (msg.action && msg.action === 'pause') this.pause()
         if (msg.action && msg.action === 'unpause') this.unPause()
-        if (msg.action && msg.action === 'add-wait') this.addWait()
+        if (msg.action && msg.action === 'wait') this.wait()
+        if (msg.action && msg.action === 'wait-for') this.waitFor()
         if (msg.action && msg.action === 'text-click') this.textClick()
       })
     })
   }
 
-  addWait(){
-    this.handleMessage({ action: pptrActions.ADD_WAIT });
+  wait(){
+    this.handleMessage({ action: pptrActions.WAIT });
+  }
+
+  waitFor() {
+    this.handleMessage({ action: pptrActions.WAIT_FOR });
   }
 
   textClick(){

--- a/src/code-generator/CodeGenerator.js
+++ b/src/code-generator/CodeGenerator.js
@@ -78,8 +78,10 @@ export default class CodeGenerator {
 
       switch (action) {
         case 'keydown':
-          if (keyCode == 13) {
+          if (keyCode == 17) {
             this._blocks.push(this._handleKeyDown(selector, value, keyCode))
+          }
+          if (keyCode == 13) {
             this._blocks.push(this._handleEnter(selector))
           }
           break

--- a/src/code-generator/__tests__/code-generator.spec.js
+++ b/src/code-generator/__tests__/code-generator.spec.js
@@ -19,7 +19,8 @@ describe('code-generator', () => {
     const code = codeGenerator._parseEvents(events)
     const lines = code.split('\n')
     expect(lines[1].trim()).toEqual('const navigationPromise = page.waitForNavigation()')
-    expect(lines[4].trim()).toEqual("await page.click('a.link')")
+    expect(lines[3].trim()).toEqual("var item = await page.waitFor(waitTillVisible, {}, 'a.link')")
+    expect(lines[4].trim()).toEqual("await item.asElement().click()")
     expect(lines[6].trim()).toEqual('await navigationPromise')
   })
 
@@ -35,8 +36,8 @@ describe('code-generator', () => {
     const codeGenerator = new CodeGenerator()
     const result = codeGenerator._parseEvents(events)
 
-    expect(result).toContain("await page.waitForSelector('a.link')")
-    expect(result).toContain("await page.click('a.link')")
+    expect(result).toContain("var item = await page.waitFor(waitTillVisible, {}, 'a.link')")
+    expect(result).toContain("await item.asElement().click()")
   })
 
   test('it does not generate the waitForSelector code before clicks when turned off', () => {

--- a/src/code-generator/__tests__/code-generator.spec.js
+++ b/src/code-generator/__tests__/code-generator.spec.js
@@ -19,8 +19,8 @@ describe('code-generator', () => {
     const code = codeGenerator._parseEvents(events)
     const lines = code.split('\n')
     expect(lines[1].trim()).toEqual('const navigationPromise = page.waitForNavigation()')
-    expect(lines[3].trim()).toEqual("await page.waitForSelector('a.link')")
-    expect(lines[4].trim()).toEqual("await page.click('a.link')")
+    expect(lines[3].trim()).toEqual("var item = await page.waitForSelector('a.link', {visible: false})")
+    expect(lines[4].trim()).toEqual("await item.asElement().click('a.link')")
     expect(lines[6].trim()).toEqual('await navigationPromise')
   })
 
@@ -36,8 +36,8 @@ describe('code-generator', () => {
     const codeGenerator = new CodeGenerator()
     const result = codeGenerator._parseEvents(events)
 
-    expect(result).toContain("await page.waitForSelector('a.link')")
-    expect(result).toContain("await page.click('a.link')")
+    expect(result).toContain("var item = await page.waitForSelector('a.link', {visible: false})")
+    expect(result).toContain("await item.asElement().click('a.link')")
   })
 
   test('it does not generate the waitForSelector code before clicks when turned off', () => {
@@ -45,7 +45,7 @@ describe('code-generator', () => {
     const codeGenerator = new CodeGenerator({ waitForSelectorOnClick: false })
     const result = codeGenerator._parseEvents(events)
 
-    expect(result).not.toContain("await page.waitForSelector('a.link')")
+    expect(result).not.toContain("await page.waitForSelector('a.link', {visible: false})")
     expect(result).toContain("await page.click('a.link')")
   })
 

--- a/src/code-generator/__tests__/code-generator.spec.js
+++ b/src/code-generator/__tests__/code-generator.spec.js
@@ -19,8 +19,8 @@ describe('code-generator', () => {
     const code = codeGenerator._parseEvents(events)
     const lines = code.split('\n')
     expect(lines[1].trim()).toEqual('const navigationPromise = page.waitForNavigation()')
-    expect(lines[3].trim()).toEqual("var item = await page.waitFor(waitTillVisible, {}, 'a.link')")
-    expect(lines[4].trim()).toEqual("await item.asElement().click()")
+    expect(lines[3].trim()).toEqual("await page.waitForSelector('a.link')")
+    expect(lines[4].trim()).toEqual("await page.click('a.link')")
     expect(lines[6].trim()).toEqual('await navigationPromise')
   })
 
@@ -36,8 +36,8 @@ describe('code-generator', () => {
     const codeGenerator = new CodeGenerator()
     const result = codeGenerator._parseEvents(events)
 
-    expect(result).toContain("var item = await page.waitFor(waitTillVisible, {}, 'a.link')")
-    expect(result).toContain("await item.asElement().click()")
+    expect(result).toContain("await page.waitForSelector('a.link')")
+    expect(result).toContain("await page.click('a.link')")
   })
 
   test('it does not generate the waitForSelector code before clicks when turned off', () => {

--- a/src/code-generator/elements-to-bind-to.js
+++ b/src/code-generator/elements-to-bind-to.js
@@ -14,5 +14,11 @@ export default [
   'h6',
   'div',
   'span',
-  'img'
+  'img',
+  'nav-side-bar-item-name',
+  'view-list-item-name',
+  'nav-side-bar-option',
+  'search-result',
+  'compose-side-bar-search-box',
+  'dropdown'
 ]

--- a/src/code-generator/elements-to-bind-to.js
+++ b/src/code-generator/elements-to-bind-to.js
@@ -14,11 +14,5 @@ export default [
   'h6',
   'div',
   'span',
-  'img',
-  'nav-side-bar-item-name',
-  'view-list-item-name',
-  'nav-side-bar-option',
-  'search-result',
-  'compose-side-bar-search-box',
-  'dropdown'
+  'img'
 ]

--- a/src/code-generator/pptr-actions.js
+++ b/src/code-generator/pptr-actions.js
@@ -7,5 +7,6 @@ export default {
   FRAME_SET: 'frame-set*',
   WAIT: 'wait*',
   WAIT_FOR: 'wait-for*',
-  TEXT_CLICK: 'text-click*'
+  TEXT_CLICK: 'text-click*',
+  SET_LOCAL_STORAGE: 'set-local-storage*'
 }

--- a/src/code-generator/pptr-actions.js
+++ b/src/code-generator/pptr-actions.js
@@ -5,6 +5,7 @@ export default {
   NAVIGATION: 'navigation*',
   NAVIGATION_PROMISE: 'navigation-promise*',
   FRAME_SET: 'frame-set*',
-  ADD_WAIT: 'add-wait*',
+  WAIT: 'wait*',
+  WAIT_FOR: 'wait-for*',
   TEXT_CLICK: 'text-click*'
 }

--- a/src/code-generator/pptr-actions.js
+++ b/src/code-generator/pptr-actions.js
@@ -4,5 +4,6 @@ export default {
   WAITFORSELECTOR: 'waitForSelector*',
   NAVIGATION: 'navigation*',
   NAVIGATION_PROMISE: 'navigation-promise*',
-  FRAME_SET: 'frame-set*'
+  FRAME_SET: 'frame-set*',
+  ADD_WAIT: 'add-wait*'
 }

--- a/src/code-generator/pptr-actions.js
+++ b/src/code-generator/pptr-actions.js
@@ -5,5 +5,6 @@ export default {
   NAVIGATION: 'navigation*',
   NAVIGATION_PROMISE: 'navigation-promise*',
   FRAME_SET: 'frame-set*',
-  ADD_WAIT: 'add-wait*'
+  ADD_WAIT: 'add-wait*',
+  TEXT_CLICK: 'text-click*'
 }

--- a/src/content-scripts/index.js
+++ b/src/content-scripts/index.js
@@ -70,12 +70,16 @@ class EventRecorder {
 
     const msg = {
       selector: finder(e.target, { seedMinLength: 5, optimizedMinLength: 10 }),
+      altKey: e.altKey,
+      shiftKey: e.shiftKey,
+      ctrlKey: e.ctrlKey,
       value: e.target.value,
       tagName: e.target.tagName,
       action: e.type,
       keyCode: e.keyCode ? e.keyCode : null,
       href: e.target.href ? e.target.href : null,
-      coordinates: getCoordinates(e)
+      coordinates: getCoordinates(e),
+      innerText: e.target.innerText
     }
     this.sendMessage(msg)
   }

--- a/src/options/components/App.vue
+++ b/src/options/components/App.vue
@@ -61,6 +61,18 @@
                 the keycode that indicates that the user is done typing and emit the <code>type()</code> instruction
               </label>
             </div>
+            <div class="settings-group">
+              <label>
+                <textarea id="options-code-cookies" v-model="options.code.cookies" @change="save"></textarea>
+                a json value that defines the cookies to add to the page.
+              </label>
+            </div>
+            <div class="settings-group">
+              <label>
+                <textarea id="options-code-localStorage" v-model="options.code.localStorage" @change="save"></textarea>
+                a json value that defines the local storage values to add to the page.
+              </label>
+            </div>
           </div>
         </div>
       </div>

--- a/src/options/components/App.vue
+++ b/src/options/components/App.vue
@@ -39,8 +39,8 @@
             </div>
             <div class="settings-group">
               <label>
-                <input id="options-code-waitTillVisibleOnClick" type="checkbox" v-model="options.code.waitTillVisibleOnClick" @change="save">
-                add <code>waitTillVisible</code> lines before every <code>page.click()</code>
+                <input id="options-code-waitTillVisible" type="checkbox" v-model="options.code.waitTillVisible" @change="save">
+                 <code>waitForSelector</code> will also wait till the element is considered visible
               </label>
             </div>
             <div class="settings-group">
@@ -51,7 +51,7 @@
             </div>
             <div class="settings-group">
               <label>
-                <input id="options-code-addWait" type="textbox" v-model="options.code.addWait" @change="save">
+                <input id="options-code-wait" type="textbox" v-model="options.code.wait" @change="save">
                 the timeout value for <code>page.waitFor(timeout)</code>
               </label>
             </div>

--- a/src/options/components/App.vue
+++ b/src/options/components/App.vue
@@ -34,6 +34,12 @@
             <div class="settings-group">
               <label>
                 <input id="options-code-waitForSelectorOnClick" type="checkbox" v-model="options.code.waitForSelectorOnClick" @change="save">
+                add <code>waitForSelector</code> lines before every <code>page.click()</code>
+              </label>
+            </div>
+            <div class="settings-group">
+              <label>
+                <input id="options-code-waitTillVisibleOnClick" type="checkbox" v-model="options.code.waitTillVisibleOnClick" @change="save">
                 add <code>waitTillVisible</code> lines before every <code>page.click()</code>
               </label>
             </div>
@@ -47,6 +53,12 @@
               <label>
                 <input id="options-code-addWait" type="textbox" v-model="options.code.addWait" @change="save">
                 the timeout value for <code>page.waitFor(timeout)</code>
+              </label>
+            </div>
+            <div class="settings-group">
+              <label>
+                <input id="options-code-typingTerminator" type="textbox" v-model="options.code.typingTerminator" @change="save">
+                the keycode that indicates that the user is done typing and emit the <code>type()</code> instruction
               </label>
             </div>
           </div>

--- a/src/options/components/App.vue
+++ b/src/options/components/App.vue
@@ -34,13 +34,19 @@
             <div class="settings-group">
               <label>
                 <input id="options-code-waitForSelectorOnClick" type="checkbox" v-model="options.code.waitForSelectorOnClick" @change="save">
-                add <code>waitForSelector</code> lines before every <code>page.click()</code>
+                add <code>waitTillVisible</code> lines before every <code>page.click()</code>
               </label>
             </div>
             <div class="settings-group">
               <label>
                 <input id="options-code-blankLinesBetweenBlocks" type="checkbox" v-model="options.code.blankLinesBetweenBlocks" @change="save">
                 add blank lines between code blocks
+              </label>
+            </div>
+            <div class="settings-group">
+              <label>
+                <input id="options-code-addWait" type="textbox" v-model="options.code.addWait" @change="save">
+                the timeout value for <code>page.waitFor(timeout)</code>
               </label>
             </div>
           </div>

--- a/src/popup/components/App.vue
+++ b/src/popup/components/App.vue
@@ -33,6 +33,9 @@
           <button class="btn btn-sm btn-primary" @click="addWait" v-show="isRecording">
             {{addWaitButtonText}}
           </button>
+          <button class="btn btn-sm btn-primary" @click="textClick" v-show="isRecording">
+            {{textClickButtonText}}
+          </button>
         </div>
         <ResultsTab :code="code" :copy-link-text="copyLinkText" :restart="restart" :set-copying="setCopying" v-show="showResultsTab"/>
         <div class="results-footer" v-show="showResultsTab">
@@ -108,6 +111,10 @@
       addWait () {
         console.debug('adding wait')
         this.bus.postMessage({ action: 'add-wait' })
+      },
+      textClick() {
+        console.debug('text click')
+        this.bus.postMessage({ action: 'text-click' })
       },
       start () {
         this.cleanUp()
@@ -191,6 +198,9 @@
       },
       addWaitButtonText () {
         return 'Add Wait'
+      },
+      textClickButtonText () {
+        return 'Text Click'
       },
       pauseButtonText () {
         return this.isPaused ? 'Resume' : 'Pause'

--- a/src/popup/components/App.vue
+++ b/src/popup/components/App.vue
@@ -29,6 +29,11 @@
           </button>
           <a href="#" @click="showResultsTab = true" v-show="code">view code</a>
         </div>
+        <div class="recording-footer" v-show="isRecording">
+          <button class="btn btn-sm btn-primary" @click="addWait" v-show="isRecording">
+            {{addWaitButtonText}}
+          </button>
+        </div>
         <ResultsTab :code="code" :copy-link-text="copyLinkText" :restart="restart" :set-copying="setCopying" v-show="showResultsTab"/>
         <div class="results-footer" v-show="showResultsTab">
           <button class="btn btn-sm btn-primary" @click="restart" v-show="code">Restart</button>
@@ -99,6 +104,10 @@
           this.isPaused = true
         }
         this.storeState()
+      },
+      addWait () {
+        console.debug('adding wait')
+        this.bus.postMessage({ action: 'add-wait' })
       },
       start () {
         this.cleanUp()
@@ -179,6 +188,9 @@
       },
       recordButtonText () {
         return this.isRecording ? 'Stop' : 'Record'
+      },
+      addWaitButtonText () {
+        return 'Add Wait'
       },
       pauseButtonText () {
         return this.isPaused ? 'Resume' : 'Pause'

--- a/src/popup/components/App.vue
+++ b/src/popup/components/App.vue
@@ -30,8 +30,11 @@
           <a href="#" @click="showResultsTab = true" v-show="code">view code</a>
         </div>
         <div class="recording-footer" v-show="isRecording">
-          <button class="btn btn-sm btn-primary" @click="addWait" v-show="isRecording">
-            {{addWaitButtonText}}
+          <button class="btn btn-sm btn-primary" @click="wait" v-show="isRecording">
+            {{waitButtonText}}
+          </button>
+          <button class="btn btn-sm btn-primary" @click="waitFor" v-show="isRecording">
+            {{waitForButtonText}}
           </button>
           <button class="btn btn-sm btn-primary" @click="textClick" v-show="isRecording">
             {{textClickButtonText}}
@@ -108,9 +111,13 @@
         }
         this.storeState()
       },
-      addWait () {
+      wait () {
         console.debug('adding wait')
-        this.bus.postMessage({ action: 'add-wait' })
+        this.bus.postMessage({ action: 'wait' })
+      },
+      waitFor () {
+        console.debug('wait for')
+        this.bus.postMessage({ action: 'wait-for' })
       },
       textClick() {
         console.debug('text click')
@@ -196,8 +203,11 @@
       recordButtonText () {
         return this.isRecording ? 'Stop' : 'Record'
       },
-      addWaitButtonText () {
-        return 'Add Wait'
+      waitForButtonText () {
+        return 'Wait For'
+      },
+      waitButtonText () {
+        return 'Wait'
       },
       textClickButtonText () {
         return 'Text Click'

--- a/src/popup/components/__tests__/__snapshots__/App.spec.js.snap
+++ b/src/popup/components/__tests__/__snapshots__/App.spec.js.snap
@@ -112,6 +112,15 @@ exports[`App.vue it has the correct pristine / empty state 1`] = `
           Add Wait
         
         </button>
+         
+        <button
+          class="btn btn-sm btn-primary"
+          style="display: none;"
+        >
+          
+          Text Click
+        
+        </button>
       </div>
        
       <resultstab-stub

--- a/src/popup/components/__tests__/__snapshots__/App.spec.js.snap
+++ b/src/popup/components/__tests__/__snapshots__/App.spec.js.snap
@@ -109,7 +109,16 @@ exports[`App.vue it has the correct pristine / empty state 1`] = `
           style="display: none;"
         >
           
-          Add Wait
+          Wait
+        
+        </button>
+         
+        <button
+          class="btn btn-sm btn-primary"
+          style="display: none;"
+        >
+          
+          Wait For
         
         </button>
          

--- a/src/popup/components/__tests__/__snapshots__/App.spec.js.snap
+++ b/src/popup/components/__tests__/__snapshots__/App.spec.js.snap
@@ -100,6 +100,20 @@ exports[`App.vue it has the correct pristine / empty state 1`] = `
         </a>
       </div>
        
+      <div
+        class="recording-footer"
+        style="display: none;"
+      >
+        <button
+          class="btn btn-sm btn-primary"
+          style="display: none;"
+        >
+          
+          Add Wait
+        
+        </button>
+      </div>
+       
       <resultstab-stub
         code=""
         copy-link-text="copy to clipboard"


### PR DESCRIPTION
Hopefully these changes are not considered offensive.
The new features should be considered beta and may be modified in the future.

- The keycode that emits the `type()` instruction is now configurable on the options page. It defaults to 9 (tab)

- Pressing `enter` will emit a `page.keyboard.press("Enter")` instruction. Maybe this should be configurable.

- New option to cause waitForSelector to also use {visible: true/false}.

- New cookies option. A json value that defines the cookies to add to the page

```
[
   {
      "name":"accessToken",
      "value":"",
      "domain":".fake.com",
      "path":"/"
   },
   {
      "name":"namespace",
      "value":"alpha",
      "domain":".fake.com",
      "path":"/"
   }
]
```

- New local storage option. A json value that defines the local storage to add to the page.

```
{
    "localstorageoption1": "1",
    "localstorageoption2": "0"
}
```

- Added an addition toolbar under the recording toolbar. Needs work.

- The new toolbar contains new option 'Wait'. Clicking the 'Wait' button emits a `page.waitFor(timeout)` instruction. The timeout value is configurable in the options and defaults to 2000 (two seconds).

- The new toolbar contains new option 'Text Click'. This name is bad. Clicking this button and then clicking on an element will emit a `waitForXPath` instruction followed by a click instruction. Additionally it causes the waitForXPath method to force a match based on the normalized innerText of the element. This is useful when the  element being clicked on is not always at the same css path.

- The new toolbar contains new option 'Wait For'. Clicking this button and then clicking on an element will emit a `waitForXPath` instruction. Additionally it causes the waitForXPath method to force a match based on the normalized innerText of the element. This is useful when the  element being clicked on is not always at the same css path.

Sanitized sample script using new code generation.

```
const puppeteer = require('puppeteer');
const browser = await puppeteer.launch()
const page = await browser.newPage()
await page.setCookie({"name":"accessToken","value":"","domain":".fake.com","path":"/"})
await page.setCookie({"name":"namespace","value":"alpha","domain":".fake.com","path":"/"})

await page.setViewport({ width: 1932, height: 604 })

await page.goto('https://www.fake.com')

await page.evaluate(() => {
  localStorage.setItem("localstorageoption1", "1")
  localStorage.setItem("localstorageoption2", "0")
})

var item = await page.waitForXPath('//EXPANDED-SIDE-BAR-HEADER-ITEM-TEXT[normalize-space() = "Mailboxes"]', {visible: true})

var item = await page.waitForSelector('nav-side-bar-option:nth-child(3)', {visible: true})
await item.asElement().click('nav-side-bar-option:nth-child(3)')

var item = await page.waitForSelector('.search-box', {visible: true})
await item.asElement().type('Smoke')

await page.keyboard.press('Enter');

var item = await page.waitForXPath('//SEARCH-RESULT-TITLE[normalize-space() = "Smoke Test"]', {visible: true})
await item.asElement().click()

page.waitFor(2000)
await browser.close()
```
