### PR TITLE
feature(prefer-id-selector)

### DIFF
--- a/src/content-scripts/index.js
+++ b/src/content-scripts/index.js
@@ -9,7 +9,7 @@ class EventRecorder {
     this.isTopFrame = (window.location === window.parent.location)
   }
 
-  start () {
+  boot () {
     // We need to check the existence of chrome for testing purposes
     if (chrome.storage && chrome.storage.local) {
       chrome.storage.local.get(['options'], ({options}) => {
@@ -72,9 +72,10 @@ class EventRecorder {
     // we explicitly catch any errors and swallow them, as none node-type events are also ingested.
     // for these events we cannot generate selectors, which is OK
     try {
+      const optimizedMinLength = (e.target.id) ? 2 : 10 // if the target has an id, use that instead of multiple other selectors
       const selector = this.dataAttribute && e.target.hasAttribute && e.target.hasAttribute(this.dataAttribute)
         ? formatDataSelector(e.target, this.dataAttribute)
-        : finder(e.target, {seedMinLength: 5, optimizedMinLength: 10})
+        : finder(e.target, {seedMinLength: 5, optimizedMinLength: optimizedMinLength})
 
       const msg = {
         selector: selector,
@@ -113,4 +114,4 @@ function formatDataSelector (element, attribute) {
 }
 
 window.eventRecorder = new EventRecorder()
-window.eventRecorder.start()
+window.eventRecorder.boot()


### PR DESCRIPTION
Fixes #32
## Description

It prefers selector id and avoid extra selector. I also renamed `EventRecorder.start()` to `EventRecorder.boot()` to make the pattern similar to `RecordingController.boot()`

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I ran the unit test just fine.

## Checklist:

- [X] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
