### PR TITLE
Bug: togglePause on re-opening popup fixed

### DIFF
--- a/src/popup/components/App.vue
+++ b/src/popup/components/App.vue
@@ -143,7 +143,7 @@ export default {
           console.debug('loaded controls', controls)
           if (controls) {
             this.isRecording = controls.isRecording
-            this.isPaused = controls._isPaused
+            this.isPaused = controls.isPaused
           }
 
           if (code) {


### PR DESCRIPTION
The state did not load correctly after closing the popup and re-opening it again. The state would instead be the default state (isPaused=false) because the state was saved to _isPaused, which is wrong! After removing the lowdash and saving the state back to the actual state isPaused the pause-button is working again correctly.

# Pull Request Template

## Description

Please include a summary of the change or which issue is fixed. Also, include relevant motivation and context.
Remember, as mentioned in the [contribution guidelines](https://github.com/checkly/puppeteer-recorder/blob/master/CONTRIBUTING.md) that
PR's should be as atomic as possible 1 feature === 1 PR. 1 bugfix === 1 PR.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
