### PR TITLE
Feat anscestor attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "puppeteer-recorder",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -140,9 +140,9 @@
       }
     },
     "@medv/finder": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@medv/finder/-/finder-1.1.0.tgz",
-      "integrity": "sha512-UPjX+hWYTxYQioAMG2xk7Cm/kh/NbPNQaQWjO4a1lS04ns4xMINDxlXljrCt2ODGrtFkGSsU6iVm3+gUK8KT4A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@medv/finder/-/finder-1.1.2.tgz",
+      "integrity": "sha512-lSwZQxhfc4SEsEPQCgZ6UEewgRkKQ/el23aKCoSa2psiJt2pPoJCR3shCXK6+aGcjxLAwzDpsMic/MV9Bumf1g==",
       "requires": {
         "cssesc": "^2.0.0"
       },
@@ -460,7 +460,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -472,7 +471,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -4518,8 +4516,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4540,14 +4537,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4562,20 +4557,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4692,8 +4684,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4705,7 +4696,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4720,7 +4710,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4728,14 +4717,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4754,7 +4741,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4835,8 +4821,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4848,7 +4833,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4934,8 +4918,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4971,7 +4954,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4991,7 +4973,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5035,14 +5016,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -7473,9 +7452,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.assign": {
@@ -7530,8 +7509,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/checkly/puppeteer-recorder#readme",
   "dependencies": {
-    "@medv/finder": "github:ephetic/finder#feat_attribute-support",
+    "@medv/finder": "^1.1.2",
     "events": "^3.0.0",
     "vue": "^2.5.17",
     "vue-clipboard2": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/checkly/puppeteer-recorder#readme",
   "dependencies": {
-    "@medv/finder": "^1.1.0",
+    "@medv/finder": "github:ephetic/finder#feat_attribute-support",
     "events": "^3.0.0",
     "vue": "^2.5.17",
     "vue-clipboard2": "^0.2.1",

--- a/src/content-scripts/EventRecorder.js
+++ b/src/content-scripts/EventRecorder.js
@@ -101,8 +101,8 @@ export default class EventRecorder {
     // for these events we cannot generate selectors, which is OK
     try {
       const optimizedMinLength = (e.target.id) ? 2 : 10 // if the target has an id, use that instead of multiple other selectors
-      const selector = this._dataAttribute && e.target.hasAttribute && e.target.hasAttribute(this._dataAttribute)
-        ? EventRecorder._formatDataSelector(e.target, this._dataAttribute)
+      const selector = this._dataAttribute
+        ? finder(e.target, {seedMinLength: 5, optimizedMinLength: optimizedMinLength, attr: (name, _value) => name === this._dataAttribute})
         : finder(e.target, {seedMinLength: 5, optimizedMinLength: optimizedMinLength})
 
       const msg = {

--- a/src/content-scripts/__tests__/attributes.spec.js
+++ b/src/content-scripts/__tests__/attributes.spec.js
@@ -4,6 +4,7 @@ import {launchPuppeteerWithExtension, runDist} from '../../__e2e-tests__/helpers
 import { waitForAndGetEvents, cleanEventLog, startServer } from './helpers'
 
 let server
+let port
 let browser
 let page
 
@@ -12,7 +13,11 @@ describe.only('attributes', () => {
     await runDist()
     const buildDir = process.env.NODE_ENV === 'production' ? '../../../dist' : '../../../build'
     const fixture = './fixtures/attributes.html'
-    server = await startServer(buildDir, fixture)
+    {
+      const {server: _s, port: _p} = await startServer(buildDir, fixture)
+      server = _s
+      port = _p
+    }
     return done()
   }, 20000)
 
@@ -25,7 +30,7 @@ describe.only('attributes', () => {
   beforeEach(async () => {
     browser = await launchPuppeteerWithExtension(puppeteer)
     page = await browser.newPage()
-    await page.goto('http://localhost:3000/')
+    await page.goto(`http://localhost:${port}/`)
     await cleanEventLog(page)
   })
 

--- a/src/content-scripts/__tests__/attributes.spec.js
+++ b/src/content-scripts/__tests__/attributes.spec.js
@@ -1,0 +1,49 @@
+import puppeteer from 'puppeteer'
+import _ from 'lodash'
+import {launchPuppeteerWithExtension, runDist} from '../../__e2e-tests__/helpers'
+import { waitForAndGetEvents, cleanEventLog, startServer } from './helpers'
+
+let server
+let browser
+let page
+
+describe.only('attributes', () => {
+  beforeAll(async (done) => {
+    await runDist()
+    const buildDir = process.env.NODE_ENV === 'production' ? '../../../dist' : '../../../build'
+    const fixture = './fixtures/attributes.html'
+    server = await startServer(buildDir, fixture)
+    return done()
+  }, 20000)
+
+  afterAll(done => {
+    server.close(() => {
+      return done()
+    })
+  })
+
+  beforeEach(async () => {
+    browser = await launchPuppeteerWithExtension(puppeteer)
+    page = await browser.newPage()
+    await page.goto('http://localhost:3000/')
+    await cleanEventLog(page)
+  })
+
+  afterEach(async () => {
+    browser.close()
+  })
+
+  test('it should load the content', async () => {
+    const content = await page.$('#content-root')
+    expect(content).toBeTruthy()
+  })
+
+  test('it should use data attributes throughout selector', async () => {
+    await page.evaluate('window.eventRecorder._dataAttribute = "data-qa"')
+    await page.click('span')
+
+    const event = (await waitForAndGetEvents(page, 1))[0]
+    expect(event.selector).toEqual('body > #content-root > [data-qa="article-wrapper"] > [data-qa="article-body"] > span')
+  })
+
+})

--- a/src/content-scripts/__tests__/fixtures/attributes.html
+++ b/src/content-scripts/__tests__/fixtures/attributes.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>forms</title>
+</head>
+<body>
+<div id="content-root">
+  <div data-qa="article-wrapper" class="wrapper">
+    <h1 data-qa="article-title" class="title">Lorem</h1>
+    <div data-qa="article-body" class="body">
+      <span>Read More...</span>
+    </div>
+  </div>
+</div>
+<script src="/build/content-script.js" ></script>
+</body>
+</html>

--- a/src/content-scripts/__tests__/forms.spec.js
+++ b/src/content-scripts/__tests__/forms.spec.js
@@ -4,6 +4,7 @@ import {launchPuppeteerWithExtension, runDist} from '../../__e2e-tests__/helpers
 import { waitForAndGetEvents, cleanEventLog, startServer } from './helpers'
 
 let server
+let port
 let browser
 let page
 
@@ -12,7 +13,11 @@ describe('forms', () => {
     await runDist()
     const buildDir = process.env.NODE_ENV === 'production' ? '../../../dist' : '../../../build'
     const fixture = './fixtures/forms.html'
-    server = await startServer(buildDir, fixture)
+    {
+      const {server: _s, port: _p} = await startServer(buildDir, fixture)
+      server = _s
+      port = _p
+    }
     return done()
   }, 20000)
 
@@ -25,7 +30,7 @@ describe('forms', () => {
   beforeEach(async () => {
     browser = await launchPuppeteerWithExtension(puppeteer)
     page = await browser.newPage()
-    await page.goto('http://localhost:3000/')
+    await page.goto(`http://localhost:${port}/`)
     await cleanEventLog(page)
   })
 

--- a/src/content-scripts/__tests__/helpers.js
+++ b/src/content-scripts/__tests__/helpers.js
@@ -25,8 +25,21 @@ export const startServer = function (buildDir, file) {
     app.get('/', (req, res) => {
       res.status(200).sendFile(file, { root: __dirname })
     })
-    const server = app.listen(3000, () => {
-      return resolve(server)
-    })
+    let server
+    let port
+    const retry = (e) => {
+      if(e.code == 'EADDRINUSE') {
+        setTimeout(() => connect, 1000)
+      }
+    }
+    const connect = () => {
+      port = 0|(Math.random() * 1000) + 3000
+      server = app.listen(port)
+      server.once('error', retry)
+      server.once('listening', () => {
+        return resolve({server, port})
+      })
+    }
+    connect()
   })
 }


### PR DESCRIPTION
## Description

Updates use of @medv/finder to include `[data-qa="xxx"]` attributes throughout selector, not just on the clicked element.  This maximizes the value of the custom attribute setting.  See issue #52.

## Type of change

Please delete options that are not relevant.

- [√] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

A test has been created that shows clicking on a descendent `span` records a selector like

```
'body > #content-root > [data-qa="article-wrapper"] > [data-qa="article-body"] > span'
```

Existing tests unaffected.

## Checklist:

- [√] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [x] I have made corresponding changes to the documentation
- [√] I have added tests that prove my fix is effective or that my feature works
- [√] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
