### PR TITLE
chore(content-scripts): rm .only on attributes test

### DIFF
--- a/src/content-scripts/__tests__/attributes.spec.js
+++ b/src/content-scripts/__tests__/attributes.spec.js
@@ -7,7 +7,7 @@ let port
 let browser
 let page
 
-describe.only('attributes', () => {
+describe('attributes', () => {
   beforeAll(async (done) => {
     await runDist()
     const buildDir = process.env.NODE_ENV === 'production' ? '../../../dist' : '../../../build'


### PR DESCRIPTION
# Pull Request Template

## Description

Remove `.only` block on the `attributes` test. Jest parallelizes all tests so `describe.only` doesn't work to isolate the spec.

Removed to avoid any confusions 😊

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
